### PR TITLE
Fix missing postinstall in nested dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.0",
+  "version": "0.0.6-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reallyland/esm",
-      "version": "0.0.6-rc.0",
+      "version": "0.0.6-rc.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.7-rc.0",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reallyland/esm",
-      "version": "0.0.7-rc.0",
+      "version": "0.0.7",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
-        "@reallyland/tools": "^0.0.2",
+        "@reallyland/tools": "^0.0.3",
         "@rollup/plugin-commonjs": "^21.0.2",
         "@rollup/plugin-node-resolve": "^13.0.0",
         "@rollup/plugin-typescript": "^8.2.1",
@@ -218,9 +218,9 @@
       }
     },
     "node_modules/@reallyland/tools": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@reallyland/tools/-/tools-0.0.2.tgz",
-      "integrity": "sha512-iGYK1sI7cJxHFXW0myVpBLpQV84bZG7ymYCo55RS0dl6o90ausZIXb8K5HIxJ6sCOneny3McMbhcIAK10FEV3A==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@reallyland/tools/-/tools-0.0.3.tgz",
+      "integrity": "sha512-I5XAmFPTk0gdkCH5Lu2mLpe2yo5SsKLr2Od5b7RB1AkE45EpLs5J8wLnKOg0uyozqw1XcG5l7UKrrZWALp4wwQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2460,9 +2460,9 @@
       }
     },
     "@reallyland/tools": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@reallyland/tools/-/tools-0.0.2.tgz",
-      "integrity": "sha512-iGYK1sI7cJxHFXW0myVpBLpQV84bZG7ymYCo55RS0dl6o90ausZIXb8K5HIxJ6sCOneny3McMbhcIAK10FEV3A==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@reallyland/tools/-/tools-0.0.3.tgz",
+      "integrity": "sha512-I5XAmFPTk0gdkCH5Lu2mLpe2yo5SsKLr2Od5b7RB1AkE45EpLs5J8wLnKOg0uyozqw1XcG5l7UKrrZWALp4wwQ==",
       "dev": true,
       "requires": {
         "@commitlint/config-conventional": "^16.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6",
+  "version": "0.0.7-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reallyland/esm",
-      "version": "0.0.6",
+      "version": "0.0.7-rc.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.8",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reallyland/esm",
-      "version": "0.0.6-rc.8",
+      "version": "0.0.6",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.2",
+  "version": "0.0.6-rc.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reallyland/esm",
-      "version": "0.0.6-rc.2",
+      "version": "0.0.6-rc.3",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.5",
+  "version": "0.0.6-rc.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reallyland/esm",
-      "version": "0.0.6-rc.5",
+      "version": "0.0.6-rc.6",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.3",
+  "version": "0.0.6-rc.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reallyland/esm",
-      "version": "0.0.6-rc.3",
+      "version": "0.0.6-rc.4",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.4",
+  "version": "0.0.6-rc.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reallyland/esm",
-      "version": "0.0.6-rc.4",
+      "version": "0.0.6-rc.5",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.7",
+  "version": "0.0.6-rc.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reallyland/esm",
-      "version": "0.0.6-rc.7",
+      "version": "0.0.6-rc.8",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.1",
+  "version": "0.0.6-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reallyland/esm",
-      "version": "0.0.6-rc.1",
+      "version": "0.0.6-rc.2",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.5",
+  "version": "0.0.6-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reallyland/esm",
-      "version": "0.0.5",
+      "version": "0.0.6-rc.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.6",
+  "version": "0.0.6-rc.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reallyland/esm",
-      "version": "0.0.6-rc.6",
+      "version": "0.0.6-rc.7",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.1",
+  "version": "0.0.6-rc.2",
   "description": "A collection of node modules re-exported as ES Modules",
   "keywords": [
     "esm",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "build": "npm run clean && rollup --config ./rollup.config.js",
     "clean": "sh $(dirname '$0')/node_modules/@reallyland/tools/cleanup.sh",
-    "postinstall": "pwd && echo $0 && echo $(dirname '$0') && ls -halt $(pwd)/node_modules/@reallyland/tools && sh $(dirname '$0')/node_modules/@reallyland/tools/postinstall.sh",
+    "postinstall": "pwd && echo $0 && echo $(dirname '$0') && echo $(npm root) && ls -halt $(pwd)/node_modules/@reallyland/tools && sh $(dirname '$0')/node_modules/@reallyland/tools/postinstall.sh",
     "lint-commit": "sh $(dirname '$0')/node_modules/@reallyland/tools/lint-commit.sh",
     "pre-commit": "package-check && tsc --noEmit",
     "prepublishOnly": "npm run build"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "build": "npm run clean && rollup --config ./rollup.config.js",
     "clean": "sh $(dirname '$0')/node_modules/@reallyland/tools/cleanup.sh",
-    "postinstall": "pwd && echo $0 && ls -halt $(pwd)/node_modules && sh $(dirname '$0')/node_modules/@reallyland/tools/postinstall.sh",
+    "postinstall": "pwd && echo $0 && ls -halt $(pwd)/node_modules/@reallyland/tools && sh $(dirname '$0')/node_modules/@reallyland/tools/postinstall.sh",
     "lint-commit": "sh $(dirname '$0')/node_modules/@reallyland/tools/lint-commit.sh",
     "pre-commit": "package-check && tsc --noEmit",
     "prepublishOnly": "npm run build"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.6",
+  "version": "0.0.6-rc.7",
   "description": "A collection of node modules re-exported as ES Modules",
   "keywords": [
     "esm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.3",
+  "version": "0.0.6-rc.4",
   "description": "A collection of node modules re-exported as ES Modules",
   "keywords": [
     "esm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.8",
+  "version": "0.0.6",
   "description": "A collection of node modules re-exported as ES Modules",
   "keywords": [
     "esm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6",
+  "version": "0.0.7-rc.0",
   "description": "A collection of node modules re-exported as ES Modules",
   "keywords": [
     "esm",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
   ],
   "scripts": {
     "build": "npm run clean && rollup --config ./rollup.config.js",
-    "clean": "sh ./node_modules/@reallyland/tools/cleanup.sh",
-    "postinstall": "sh ./node_modules/@reallyland/tools/postinstall.sh",
-    "lint-commit": "sh ./node_modules/@reallyland/tools/lint-commit.sh",
+    "clean": "sh $(dirname '$0')/node_modules/@reallyland/tools/cleanup.sh",
+    "postinstall": "pwd && sh $(dirname '$0')/node_modules/@reallyland/tools/postinstall.sh",
+    "lint-commit": "sh $(dirname '$0')/node_modules/@reallyland/tools/lint-commit.sh",
     "pre-commit": "package-check && tsc --noEmit",
     "prepublishOnly": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.2",
+  "version": "0.0.6-rc.3",
   "description": "A collection of node modules re-exported as ES Modules",
   "keywords": [
     "esm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.5",
+  "version": "0.0.6-rc.0",
   "description": "A collection of node modules re-exported as ES Modules",
   "keywords": [
     "esm",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "commit-msg": "npm run lint-commit"
   },
   "devDependencies": {
-    "@reallyland/tools": "^0.0.2",
+    "@reallyland/tools": "^0.0.3",
     "@rollup/plugin-commonjs": "^21.0.2",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-typescript": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.4",
+  "version": "0.0.6-rc.5",
   "description": "A collection of node modules re-exported as ES Modules",
   "keywords": [
     "esm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.7-rc.0",
+  "version": "0.0.7",
   "description": "A collection of node modules re-exported as ES Modules",
   "keywords": [
     "esm",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "build": "npm run clean && rollup --config ./rollup.config.js",
     "clean": "sh $(dirname '$0')/node_modules/@reallyland/tools/cleanup.sh",
-    "postinstall": "pwd && echo $0 && ls -halt ../node_modules && sh $(dirname '$0')/node_modules/@reallyland/tools/postinstall.sh",
+    "postinstall": "pwd && echo $0 && ls -halt $(pwd)/node_modules && sh $(dirname '$0')/node_modules/@reallyland/tools/postinstall.sh",
     "lint-commit": "sh $(dirname '$0')/node_modules/@reallyland/tools/lint-commit.sh",
     "pre-commit": "package-check && tsc --noEmit",
     "prepublishOnly": "npm run build"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "build": "npm run clean && rollup --config ./rollup.config.js",
     "clean": "sh $(dirname '$0')/node_modules/@reallyland/tools/cleanup.sh",
-    "postinstall": "pwd && echo $0 && ls -halt $(pwd)/node_modules/@reallyland/tools && sh $(dirname '$0')/node_modules/@reallyland/tools/postinstall.sh",
+    "postinstall": "pwd && echo $0 && echo $(dirname '$0') && ls -halt $(pwd)/node_modules/@reallyland/tools && sh $(dirname '$0')/node_modules/@reallyland/tools/postinstall.sh",
     "lint-commit": "sh $(dirname '$0')/node_modules/@reallyland/tools/lint-commit.sh",
     "pre-commit": "package-check && tsc --noEmit",
     "prepublishOnly": "npm run build"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.5",
+  "version": "0.0.6-rc.6",
   "description": "A collection of node modules re-exported as ES Modules",
   "keywords": [
     "esm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.0",
+  "version": "0.0.6-rc.1",
   "description": "A collection of node modules re-exported as ES Modules",
   "keywords": [
     "esm",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "build": "npm run clean && rollup --config ./rollup.config.js",
     "clean": "sh $(dirname '$0')/node_modules/@reallyland/tools/cleanup.sh",
-    "postinstall": "pwd && sh $(dirname '$0')/node_modules/@reallyland/tools/postinstall.sh",
+    "postinstall": "pwd && echo $0 && ls -halt ../node_modules && sh $(dirname '$0')/node_modules/@reallyland/tools/postinstall.sh",
     "lint-commit": "sh $(dirname '$0')/node_modules/@reallyland/tools/lint-commit.sh",
     "pre-commit": "package-check && tsc --noEmit",
     "prepublishOnly": "npm run build"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "build": "npm run clean && rollup --config ./rollup.config.js",
     "clean": "sh $(npm root)/@reallyland/tools/cleanup.sh",
-    "postinstall": "if [ -f \"$(npm root)/@reallyland/tools/postinstall.sh\" ]; then sh \"$FILE\"; fi",
+    "postinstall": "$FILE=\"$(npm root)/@reallyland/tools/postinstall.sh\"; if [ -f \"$FILE\" ]; then sh \"$FILE\"; fi",
     "lint-commit": "sh $(npm root)/@reallyland/tools/lint-commit.sh",
     "pre-commit": "package-check && tsc --noEmit",
     "prepublishOnly": "npm run build"

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
   ],
   "scripts": {
     "build": "npm run clean && rollup --config ./rollup.config.js",
-    "clean": "sh $(dirname '$0')/node_modules/@reallyland/tools/cleanup.sh",
-    "postinstall": "pwd && echo $0 && echo $(dirname '$0') && echo $(npm root) && ls -halt $(pwd)/node_modules/@reallyland/tools && sh $(dirname '$0')/node_modules/@reallyland/tools/postinstall.sh",
-    "lint-commit": "sh $(dirname '$0')/node_modules/@reallyland/tools/lint-commit.sh",
+    "clean": "sh $(npm root)/@reallyland/tools/cleanup.sh",
+    "postinstall": "if [ -f \"$(npm root)/@reallyland/tools/postinstall.sh\" ]; then sh \"$FILE\"; fi",
+    "lint-commit": "sh $(npm root)/@reallyland/tools/lint-commit.sh",
     "pre-commit": "package-check && tsc --noEmit",
     "prepublishOnly": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "build": "npm run clean && rollup --config ./rollup.config.js",
     "clean": "sh $(npm root)/@reallyland/tools/cleanup.sh",
-    "postinstall": "$FILE=\"$(npm root)/@reallyland/tools/postinstall.sh\"; if [ -f \"$FILE\" ]; then sh \"$FILE\"; fi",
+    "postinstall": "FILE=\"$(npm root)/@reallyland/tools/postinstall.sh\"; if [ -f \"$FILE\" ]; then sh \"$FILE\"; fi",
     "lint-commit": "sh $(npm root)/@reallyland/tools/lint-commit.sh",
     "pre-commit": "package-check && tsc --noEmit",
     "prepublishOnly": "npm run build"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reallyland/esm",
-  "version": "0.0.6-rc.7",
+  "version": "0.0.6-rc.8",
   "description": "A collection of node modules re-exported as ES Modules",
   "keywords": [
     "esm",


### PR DESCRIPTION
## Changes

1. To skip `postinstall` script when postinstall script is not found for nested dependencies
1. To use `npm root`